### PR TITLE
Allow for semver ranges instead of always .gte()

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ $ npm install assert-npm-version
 ## Usage
 ### cli
 ```sh
-$ assert-npm-version 2.0.0
+$ assert-npm-version >=2.0.0
 ```
 
 ### package.json
 ```json
 {
   "scripts": {
-    "prepublish": "assert-npm-version 2.0.0"
+    "prepublish": "assert-npm-version >=2.0.0"
   }
 }
 ```

--- a/cli.js
+++ b/cli.js
@@ -8,15 +8,15 @@ const args = minimist(process.argv.slice(2))
 const v = args._[0]
 
 if (args.help || args.h || !v) {
-  console.log('Usage: assert-npm-version <version>')
+  console.log('Usage: assert-npm-version <range>')
   exit(0)
 }
 
-if (!semver.valid(v)) exit(1, 'please provide a valid semantic version')
+if (!semver.validRange(v)) exit(1, 'please provide a valid semantic version')
 
 npv(v, function (err, ok, currVer) {
   if (err) exit(1, err)
-  if (!ok) exit(1, 'npm version ' + v + '>=' + currVer)
+  if (!ok) exit(1, 'npm version ' + currVer + ' != ' + v)
 })
 
 // exit the program

--- a/index.js
+++ b/index.js
@@ -8,6 +8,6 @@ module.exports = version
 function version (param, cb) {
   exec('npm -v', function (err, res) {
     if (err) cb(err)
-    cb(null, semver.gte(res, param), res.split('\n')[0])
+    cb(null, semver.satisfies(res, param), res.split('\n')[0])
   })
 }


### PR DESCRIPTION
Makes it possible to exclude specific known problematic versions of npm from being used.

Currently this is a breaking change – if you would prefer it be behind a flag instead let me know :) Thanks!
